### PR TITLE
Use processes directly for Elixir

### DIFF
--- a/elixir/main.exs
+++ b/elixir/main.exs
@@ -18,7 +18,7 @@ defmodule Main do
       end
     end
 
-    IO.puts("All tasks completed")
+    IO.puts("All processes completed")
   end
 end
 

--- a/elixir/main.exs
+++ b/elixir/main.exs
@@ -7,12 +7,17 @@ defmodule Main do
 
     tasks =
       for _ <- 1..num_tasks do
-        Task.async(fn ->
+        spawn_monitor(fn ->
           :timer.sleep(10000)
         end)
       end
 
-    Task.await_many(tasks, :infinity)
+    for {_pid, ref} <- tasks do
+      receive do
+        {:DOWN, ^ref, _, _, _} -> :ok
+      end
+    end
+
     IO.puts("All tasks completed")
   end
 end


### PR DESCRIPTION
Tasks are a higher-level abstraction and they will include additional features for tracking responses.

So we change Elixir to use processes directly, reflecting the other processes and reducing memory usage by ~20%.

Still worth noting that this is pretty much an apples-to-oranges comparisons in many cases: some are using OS threads, others are green threads with their own stack and heap isolation, and others are simply event loops within the same thread. A more detailed article can be found here: https://hauleth.dev/post/beam-process-memory-usage/